### PR TITLE
Fix for CRC32 compute fallure if the crc has a leading zero.

### DIFF
--- a/YuiXDCC.py
+++ b/YuiXDCC.py
@@ -287,7 +287,7 @@ def XDCC_complete(word, word_eol, userdata):
 		match = file_crc.group(0)
 		if len(match) == 10:
 			file_crc = match[1:9]
-			cal_crc = hex(binascii.crc32(open(word[1],'rb').read()))[2:]
+			cal_crc = hex(binascii.crc32(open(word[1],'rb').read()) & 0xFFFFFFFF)[2:].zfill(8)
 			if cal_crc.upper() == file_crc.upper():
 				print("\00310\002Yui>\017 Given CRC-> \00316\026\00302\002%s \017\00316\026\00301= \00302\002%s\017 <-Recv CRC \002\00309MATCH!" % (file_crc.upper(),cal_crc.upper()))
 			else:


### PR DESCRIPTION
This fixes an issue where CRC32 checksums were output without leading zeros, causing mismatches with expected values.

E.g.
Before
```
 ----------------------------------------
 Yui> Given CRC-> 016A1F33 != 16A1F33 <-Recv CRC ERROR!
 ----------------------------------------
```

After the fix
```
Yui> Given CRC-> 016A1F33 = 016A1F33 <-Recv CRC MATCH!
```